### PR TITLE
Make compatible with Wagtail 1.4.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='wagtailembedder',
-    version='0.1.5',
+    version='1.0',
     packages=['wagtailembedder'],
     include_package_data=True,
     license='BSD License',

--- a/wagtailembedder/format.py
+++ b/wagtailembedder/format.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ObjectDoesNotExist
 from django.template.loader import render_to_string
 
-from wagtail.wagtailsnippets.views.snippets import get_snippet_model_from_url_params
+from wagtailembedder.views.snippets import get_snippet_model_from_url_params
 
 
 def embed_to_frontend_html(id, content_type_app_name, content_type_model_name):

--- a/wagtailembedder/format.py
+++ b/wagtailembedder/format.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ObjectDoesNotExist
 from django.template.loader import render_to_string
 
-from wagtail.wagtailsnippets.views.snippets import get_content_type_from_url_params
+from wagtail.wagtailsnippets.views.snippets import get_snippet_model_from_url_params
 
 
 def embed_to_frontend_html(id, content_type_app_name, content_type_model_name):
@@ -9,8 +9,7 @@ def embed_to_frontend_html(id, content_type_app_name, content_type_model_name):
     Provides the Snippet representation through the appropiate template
     """
     try:
-        content_type = get_content_type_from_url_params(content_type_app_name, content_type_model_name)
-        model = content_type.model_class()
+        model = get_snippet_model_from_url_params(content_type_app_name, content_type_model_name)
         instance = model.objects.get(id=id)
     except ObjectDoesNotExist:
         return ''
@@ -29,8 +28,7 @@ def embed_to_editor_html(id, content_type_app_name, content_type_model_name):
     Provides the Snippet representation to display in the RichTextEditor
     """
     try:
-        content_type = get_content_type_from_url_params(content_type_app_name, content_type_model_name)
-        model = content_type.model_class()
+        model = get_snippet_model_from_url_params(content_type_app_name, content_type_model_name)
         instance = model.objects.get(id=id)
     except ObjectDoesNotExist:
         return ''

--- a/wagtailembedder/views/chooser.py
+++ b/wagtailembedder/views/chooser.py
@@ -5,10 +5,10 @@ from django.core.exceptions import PermissionDenied
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
 
 from wagtail.wagtailsnippets.permissions import user_can_edit_snippet_type
-from wagtail.wagtailsnippets.views.snippets import get_snippet_model_from_url_params
 from wagtail.wagtailsnippets.models import get_snippet_models
 
 from wagtailembedder.format import embed_to_editor_html
+from wagtailembedder.views.snippets import get_snippet_model_from_url_params
 
 
 @permission_required('wagtailadmin.access_admin')

--- a/wagtailembedder/views/snippets.py
+++ b/wagtailembedder/views/snippets.py
@@ -1,0 +1,11 @@
+try:
+    from wagtail.wagtailsnippets.views.snippets import get_snippet_model_from_url_params
+
+except ImportError:
+    from wagtail.wagtailsnippets.views.snippets import get_content_type_from_url_params
+
+    def get_snippet_model_from_url_params(app_name, model_name):
+        content_type = get_content_type_from_url_params(app_name, model_name.lower())
+        model = content_type.model_class()
+
+        return model


### PR DESCRIPTION
Fix #2 
- Make compatible with Wagtail 1.4.x while maintaining compatibility with previous versions.
- Set version number to `1.0` as per @HitDaCa request (Wagtail is on 1.x now so there is no reason for this package to be on 0.x anymore).
